### PR TITLE
chore: upgrade pip

### DIFF
--- a/scripts/experience_test.sh
+++ b/scripts/experience_test.sh
@@ -6,7 +6,8 @@ source <(curl -sSL "${DEVX_SKIT_ASSETS_GIT_URL_RAW:-https://github.com/IBM/devex
 echo "Starting Chrome web driver..."
 source <(curl -sSL "${DEVX_SKIT_ASSETS_GIT_URL_RAW:-https://github.com/IBM/devex-skit-assets/raw/v1.2.3}/scripts/start_chrome.sh")
 
-echo "Checking for pip"
+echo "Upgrading pip"
+pip3 install --upgrade pip
 pip3 -V
 
 echo "Installing Selenium Python package..."


### PR DESCRIPTION
The current version of pip that this test is using is 9.0.1, and the latest version is 22.3. Upgrading pip should get the latest version of selenium, which is 4.5 (currently installing v3.141.0).